### PR TITLE
Updated IEEEtran.bst to show access date on references with urldate field

### DIFF
--- a/7_styles/IEEEtran.bst
+++ b/7_styles/IEEEtran.bst
@@ -285,6 +285,7 @@ ENTRY
     title
     type
     url
+    urldate
     volume
     year
     yearfiled
@@ -1906,23 +1907,23 @@ cap.status.std
 %% URL
 
 FUNCTION {format.url}
-{ is.use.url
-    { url empty$
-      { "" }
-      { this.to.prev.status
-        this.status.std
-        cap.yes 'status.cap :=
-        name.url.prefix " " *
-        "\url{" * url * "}" *
-        punct.no 'this.status.punct :=
-        punct.period 'prev.status.punct :=
-        space.normal 'this.status.space :=
-        space.normal 'prev.status.space :=
-        quote.no 'this.status.quote :=
-      }
-    if$
-    }
+{ url empty$
     { "" }
+    { this.to.prev.status
+      this.status.std
+      cap.yes 'status.cap :=
+      name.url.prefix " " *
+      "\url{" * url * "}" *
+      punct.no 'this.status.punct :=
+      punct.period 'prev.status.punct :=
+      space.normal 'this.status.space :=
+      space.normal 'prev.status.space :=
+      quote.no 'this.status.quote :=
+      urldate empty$
+       { "there is url but no urldate in " cite$ * warning$ }
+       { " [Accessed: " * urldate * "]" * }
+      if$
+    }
   if$
 }
 


### PR DESCRIPTION
Added urldate field and display of the date a url was accessed (websites, articles, etc.). Must ensure bibtex file has urldate field. Overleaf sync'd bibtex file from Mendeley does not include url date attributes even on references that show the field on the Mendeley application. To fix this, download bibtex file from Mendeley to local machine and upload to overleaf or other Latex project.